### PR TITLE
Update CI branch triggers

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-      - feature/**
-      - bugfix/**
-      - release/**
     tags:
       - 'v*.*.*'
     paths-ignore:
@@ -147,7 +144,7 @@ jobs:
           name: boundingboxeditor-portable-linux
           path: build/jpackage/BoundingBoxEditor
   Build-and-Test-macOS:
-    runs-on: macOS-latest
+    runs-on: macOS-10.15
     name: Build and Test (macOS)
     steps:
       - name: Git checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - master
-      - dev
+      - feature/**
+      - bugfix/**
+      - release/**
     tags:
       - 'v*.*.*'
     paths-ignore:
@@ -18,7 +20,6 @@ on:
   pull_request:
     branches:
       - master
-      - dev
 
 env:
   JAVA_VERSION: '14.0.2'


### PR DESCRIPTION
* Triggers CI only on pull_requests and pushes to master branch.
* Explicitly sets GA runner macOS version to 10.15 (`jpackage` fails on `latest` macOS runner).

Closes #2 .