### PR TITLE
Delay CI codecov result notification

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -7,3 +7,5 @@ coverage:
       default:
         target: auto
         threshold: 5%
+  notify:
+    after_n_builds: 3

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -7,5 +7,7 @@ coverage:
       default:
         target: auto
         threshold: 5%
+
+codecov:
   notify:
     after_n_builds: 3


### PR DESCRIPTION
* Delays codecov result reporting until all 3 platform pipelines are done creating their respective coverage reports.

Closes #18 .