### PR TITLE
Remove category change contextmenu item for non-View tree cells

### DIFF
--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/ObjectTreeElementCell.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/ObjectTreeElementCell.java
@@ -141,10 +141,16 @@ class ObjectTreeElementCell extends TreeCell<Object> {
         } else {
             setGraphic(createContentBox());
 
-            if(newCellObject instanceof BoundingBoxView) {
-                contextMenu.removePolygonFeatures();
-            } else if(newCellObject instanceof BoundingPolygonView) {
+            if(newCellObject instanceof View) {
+                contextMenu.addViewFeatures();
+            } else {
+                contextMenu.removeViewFeatures();
+            }
+
+            if(newCellObject instanceof BoundingPolygonView) {
                 contextMenu.addPolygonFeatures();
+            } else {
+                contextMenu.removePolygonFeatures();
             }
 
             // Register the contextMenu with the cell.
@@ -433,14 +439,17 @@ class ObjectTreeElementCell extends TreeCell<Object> {
     }
 
     private class ObjectTreeElementContextMenu extends ContextMenu {
+        private static final int CHANGE_OBJECT_CATEGORY_ITEM_POSITION = 5;
+
         ObjectTreeElementContextMenu() {
             super(hideBoundingShapeMenuItem,
                   hideOtherBoundingShapesMenuItem,
                   hideAllBoundingShapesMenuItem,
                   showBoundingShapeMenuItem,
                   showAllBoundingShapesMenuItem,
-                  changeObjectCategoryMenuItem,
                   deleteBoundingShapeMenuItem);
+
+            getItems().add(CHANGE_OBJECT_CATEGORY_ITEM_POSITION, changeObjectCategoryMenuItem);
             setUpInternalListeners();
         }
 
@@ -475,6 +484,15 @@ class ObjectTreeElementCell extends TreeCell<Object> {
 
             addVerticesMenuItem.disableProperty().unbind();
             deleteVerticesMenuItem.disableProperty().unbind();
+        }
+
+        void addViewFeatures() {
+            if(!getItems().contains(changeObjectCategoryMenuItem)) {
+                getItems().add(CHANGE_OBJECT_CATEGORY_ITEM_POSITION, changeObjectCategoryMenuItem);
+            }
+        }
+        void removeViewFeatures() {
+            getItems().remove(changeObjectCategoryMenuItem);
         }
 
         private void setUpInternalListeners() {

--- a/src/test/java/com/github/mfl28/boundingboxeditor/ui/ObjectTreeTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/ui/ObjectTreeTests.java
@@ -323,6 +323,12 @@ class ObjectTreeTests extends BoundingBoxEditorTestBase {
         // Delete Dummy-category-item. This should delete all children recursively.
         robot.rightClickOn(newDummyCategoryTreeItem.getGraphic());
         WaitForAsyncUtils.waitForFxEvents();
+        verifyThat(robot.lookup("Change Category").tryQuery().isEmpty(), Matchers.is(true),
+                saveScreenshot(testinfo));
+        verifyThat(robot.lookup("Add Vertices").tryQuery().isEmpty(), Matchers.is(true),
+                saveScreenshot(testinfo));
+        verifyThat(robot.lookup("Remove Vertices").tryQuery().isEmpty(), Matchers.is(true),
+                saveScreenshot(testinfo));
         timeOutClickOn(robot, "Delete", testinfo);
         WaitForAsyncUtils.waitForFxEvents();
         // Now the tree-view should be empty (besides the invisible root-item).


### PR DESCRIPTION
* Removes the "Change Category" contextmenu-item for object tree cells whose corresponding cell-object is not a `View` instance.
* Adds test assertions.

Fixes #22 .