### PR TITLE
Fix reflection and modularity errors wrt. jakarta and gson.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,12 @@ jlink {
 
     forceMerge 'jakarta'
 
+    mergedModule {
+        additive = true
+        uses 'jakarta.ws.rs.client.ClientBuilder'
+        uses 'jakarta.ws.rs.ext.RuntimeDelegate'
+    }
+
     imageZip = project.file("${buildDir}/distributions/boundingboxeditor-${javafx.platform.classifier}.zip")
 
     jpackage {

--- a/src/main/java/com/github/mfl28/boundingboxeditor/model/io/restclients/BoundingBoxPredictionEntry.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/model/io/restclients/BoundingBoxPredictionEntry.java
@@ -20,6 +20,43 @@ package com.github.mfl28.boundingboxeditor.model.io.restclients;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-public record BoundingBoxPredictionEntry(Map<String, List<Double>> categoryToBoundingBoxes, Double score) {
+public final class BoundingBoxPredictionEntry {
+    private final Map<String, List<Double>> categoryToBoundingBoxes;
+    private final Double score;
+
+    public BoundingBoxPredictionEntry(Map<String, List<Double>> categoryToBoundingBoxes, Double score) {
+        this.categoryToBoundingBoxes = categoryToBoundingBoxes;
+        this.score = score;
+    }
+
+    public Map<String, List<Double>> categoryToBoundingBoxes() {
+        return categoryToBoundingBoxes;
+    }
+
+    public Double score() {
+        return score;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj == this) {
+            return true;
+        }
+
+        if(obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+
+        BoundingBoxPredictionEntry that = (BoundingBoxPredictionEntry) obj;
+
+        return Objects.equals(this.categoryToBoundingBoxes, that.categoryToBoundingBoxes) &&
+                Objects.equals(this.score, that.score);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(categoryToBoundingBoxes, score);
+    }
 }

--- a/src/main/java/com/github/mfl28/boundingboxeditor/model/io/restclients/ModelEntry.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/model/io/restclients/ModelEntry.java
@@ -18,5 +18,43 @@
  */
 package com.github.mfl28.boundingboxeditor.model.io.restclients;
 
-public record ModelEntry(String modelName, String modelUrl) {
+import java.util.Objects;
+
+public final class ModelEntry {
+    private final String modelName;
+    private final String modelUrl;
+
+    public ModelEntry(String modelName, String modelUrl) {
+        this.modelName = modelName;
+        this.modelUrl = modelUrl;
+    }
+
+    public String modelName() {
+        return modelName;
+    }
+
+    public String modelUrl() {
+        return modelUrl;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj == this) {
+            return true;
+        }
+
+        if(obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+
+        ModelEntry that = (ModelEntry) obj;
+
+        return Objects.equals(this.modelName, that.modelName) &&
+                Objects.equals(this.modelUrl, that.modelUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(modelName, modelUrl);
+    }
 }

--- a/src/test/java/com/github/mfl28/boundingboxeditor/model/io/ModelIoTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/model/io/ModelIoTests.java
@@ -21,8 +21,11 @@ package com.github.mfl28.boundingboxeditor.model.io;
 import com.github.mfl28.boundingboxeditor.model.data.BoundingBoxData;
 import com.github.mfl28.boundingboxeditor.model.data.BoundingPolygonData;
 import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;
+import com.github.mfl28.boundingboxeditor.model.io.restclients.BoundingBoxPredictionEntry;
+import com.github.mfl28.boundingboxeditor.model.io.restclients.ModelEntry;
 import javafx.geometry.BoundingBox;
 import javafx.scene.paint.Color;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -106,7 +109,15 @@ class ModelIoTests {
                                                                                                     15.0),
                                                                            Collections.emptyList());
         Assertions.assertNotEquals(boundingPolygonData1, boundingPolygonData4);
-
     }
 
+    @Test
+    void checkRestModelEntryEqualityContract() {
+        EqualsVerifier.simple().forClass(ModelEntry.class).verify();
+    }
+
+    @Test
+    void checkRestBoundingBoxPredictionEntryEqualityContract() {
+        EqualsVerifier.simple().forClass(BoundingBoxPredictionEntry.class).verify();
+    }
 }


### PR DESCRIPTION
* Explicitly add missing "uses" directives (that cannot be determined automatically) to jlink `mergeModule` section to fix modularity errors in the runtime images (-> jakarta).
* Transform `ModelEntry` and `BoundingBoxPredictionEntry` records back to data classes as  Gson does not seem to have reflective access to set the fields of records.
* Verify the equality contract of the data classes in unit tests.

Fixes #30 .