### PR TITLE
Update Github Actions Java version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ on:
       - master
 
 env:
-  JAVA_VERSION: '17'
+  JAVA_VERSION: '17.0.8+7'
   JAVA_DISTRIBUTION: 'temurin'
   TEST_SCREEN_WIDTH: '1920'
   TEST_SCREEN_HEIGHT: '1080'


### PR DESCRIPTION
* Updates the used JDK version in Github Actions workflow to 17.0.8+7 (which should include fixes for macOS signing).
* Installer now works (tested on MacOS 13.4).

Closes #68 .