### PR TITLE
Fix partial navigation key-combination release handling

### DIFF
--- a/src/main/java/com/github/mfl28/boundingboxeditor/controller/Controller.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/controller/Controller.java
@@ -509,7 +509,7 @@ public class Controller {
         }
 
         keyCombinationHandlers.stream()
-                .filter(keyCombinationHandler -> keyCombinationHandler.getKeyCombination().match(event) && keyCombinationHandler.hasOnPressedHandler())
+                .filter(keyCombinationHandler -> keyCombinationHandler.handlesPressed(event))
                 .findFirst()
                 .ifPresent(keyCombinationEventHandler -> keyCombinationEventHandler.onPressed(event));
     }
@@ -525,7 +525,7 @@ public class Controller {
         }
 
         keyCombinationHandlers.stream()
-                .filter(keyCombinationHandler -> keyCombinationHandler.getKeyCombination().match(event) && keyCombinationHandler.hasOnReleasedHandler())
+                .filter(keyCombinationHandler -> keyCombinationHandler.handlesReleased(event))
                 .findFirst()
                 .ifPresent(keyCombinationEventHandler -> keyCombinationEventHandler.onReleased(event));
     }
@@ -674,7 +674,7 @@ public class Controller {
                 "About " + PROGRAM_NAME,
                 PROGRAM_NAME,
                 "Version: " + PROGRAM_VERSION +
-                "\nLicense: " + PROGRAM_LICENSE,
+                        "\nLicense: " + PROGRAM_LICENSE,
                 stage);
     }
 
@@ -739,10 +739,16 @@ public class Controller {
 
     private List<KeyCombinationEventHandler> createKeyCombinationHandlers() {
         return List.of(
+                new KeyCombinationEventHandler(KeyCombination.NO_MATCH, null,
+                        event -> {
+                            navigatePreviousKeyPressed.set(false);
+                            navigateNextKeyPressed.set(false);
+                        },
+                        event -> KeyCombinations.navigationReleaseKeyCodes.contains(event.getCode())),
                 new KeyCombinationEventHandler(KeyCombinations.navigateNext,
-                        event -> handleNavigateNextKeyPressed(), event -> navigateNextKeyPressed.set(false)),
+                        event -> handleNavigateNextKeyPressed(), null),
                 new KeyCombinationEventHandler(KeyCombinations.navigatePrevious,
-                        event -> handleNavigatePreviousKeyPressed(), event -> navigatePreviousKeyPressed.set(false)),
+                        event -> handleNavigatePreviousKeyPressed(), null),
                 new SingleFireKeyCombinationEventHandler(KeyCombinations.deleteSelectedBoundingShape,
                         event -> view.removeSelectedTreeItemAndChildren(), null),
                 new SingleFireKeyCombinationEventHandler(KeyCombinations.removeEditingVerticesWhenBoundingPolygonSelected,
@@ -1329,7 +1335,7 @@ public class Controller {
 
     private void updateStageTitle() {
         ImageMetaData currentImageMetaData = model.getCurrentImageMetaData();
-    stage.setTitle(PROGRAM_IDENTIFIER + PROGRAM_NAME_EXTENSION_SEPARATOR
+        stage.setTitle(PROGRAM_IDENTIFIER + PROGRAM_NAME_EXTENSION_SEPARATOR
                 + model.getCurrentImageFilePath() + " " + currentImageMetaData.getDimensionsString());
     }
 
@@ -1589,6 +1595,8 @@ public class Controller {
                 KeyCombination.SHORTCUT_DOWN);
         public static final KeyCombination navigatePrevious = new KeyCodeCombination(KeyCode.A,
                 KeyCombination.SHORTCUT_DOWN);
+
+        public static final List<KeyCode> navigationReleaseKeyCodes = List.of(KeyCode.A, KeyCode.D, KeyCode.CONTROL, KeyCode.META);
         public static final KeyCombination showAllBoundingShapes =
                 new KeyCodeCombination(KeyCode.V, KeyCombination.SHORTCUT_DOWN, KeyCombination.ALT_DOWN);
         public static final KeyCombination hideAllBoundingShapes =

--- a/src/main/java/com/github/mfl28/boundingboxeditor/controller/utils/KeyCombinationEventHandler.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/controller/utils/KeyCombinationEventHandler.java
@@ -22,16 +22,37 @@ import javafx.event.EventHandler;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 
+import java.util.function.Function;
+
 public class KeyCombinationEventHandler {
     private final KeyCombination keyCombination;
     private final EventHandler<KeyEvent> onPressedHandler;
     private final EventHandler<KeyEvent> onReleasedHandler;
+    private final Function<KeyEvent, Boolean> releaseMatcher;
 
-    public KeyCombinationEventHandler(KeyCombination keyCombination, EventHandler<KeyEvent> onPressedHandler, EventHandler<KeyEvent> onReleasedHandler) {
+    public KeyCombinationEventHandler(
+            KeyCombination keyCombination,
+            EventHandler<KeyEvent> onPressedHandler,
+            EventHandler<KeyEvent> onReleasedHandler,
+            Function<KeyEvent, Boolean> releaseMatcher) {
         this.keyCombination = keyCombination;
         this.onPressedHandler = onPressedHandler;
         this.onReleasedHandler = onReleasedHandler;
+        this.releaseMatcher = releaseMatcher;
     }
+
+    public KeyCombinationEventHandler(
+            KeyCombination keyCombination,
+            EventHandler<KeyEvent> onPressedHandler,
+            EventHandler<KeyEvent> onReleasedHandler) {
+        this(
+                keyCombination,
+                onPressedHandler,
+                onReleasedHandler,
+                null
+        );
+    }
+
 
     public KeyCombination getKeyCombination() {
         return keyCombination;
@@ -55,5 +76,25 @@ public class KeyCombinationEventHandler {
         if(this.onReleasedHandler != null) {
             this.onReleasedHandler.handle(event);
         }
+    }
+
+    public boolean matchPressed(KeyEvent event) {
+        return keyCombination.match(event);
+    }
+
+    public boolean matchReleased(KeyEvent event) {
+        if(releaseMatcher != null) {
+            return releaseMatcher.apply(event);
+        } else {
+            return keyCombination.match(event);
+        }
+    }
+
+    public boolean handlesPressed(KeyEvent event) {
+        return hasOnPressedHandler() && matchPressed(event);
+    }
+
+    public boolean handlesReleased(KeyEvent event) {
+        return hasOnReleasedHandler() && matchReleased(event);
     }
 }

--- a/src/test/java/com/github/mfl28/boundingboxeditor/controller/SceneKeyShortcutTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/controller/SceneKeyShortcutTests.java
@@ -24,6 +24,7 @@ import com.github.mfl28.boundingboxeditor.ui.BoundingPolygonView;
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
 import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.stage.Stage;
@@ -57,6 +58,7 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
 
         verifyThat(controller.keyCombinationHandlers.stream().map(KeyCombinationEventHandler::getKeyCombination).toList(),
                 Matchers.containsInAnyOrder(
+                        KeyCombination.NO_MATCH,
                         Controller.KeyCombinations.navigateNext, Controller.KeyCombinations.navigatePrevious,
                         Controller.KeyCombinations.showAllBoundingShapes, Controller.KeyCombinations.hideAllBoundingShapes,
                         Controller.KeyCombinations.showSelectedBoundingShape, Controller.KeyCombinations.hideSelectedBoundingShape,
@@ -69,8 +71,12 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
                         Controller.KeyCombinations.hideNonSelectedBoundingShapes, Controller.KeyCombinations.simplifyPolygon
                 ));
 
-        testNavigateNextKeyEvent(testinfo);
-        testNavigatePreviousKeyEvent(testinfo);
+        testNavigateNextKeyEvent(testinfo, true, true, "wexor-tmg-L-2p8fapOA8-unsplash.jpg");
+        testNavigatePreviousKeyEvent(testinfo, true, true, "rachel-hisko-rEM3cK8F1pk-unsplash.jpg");
+        testNavigateNextKeyEvent(testinfo, false, true, "wexor-tmg-L-2p8fapOA8-unsplash.jpg");
+        testNavigatePreviousKeyEvent(testinfo, false, true, "rachel-hisko-rEM3cK8F1pk-unsplash.jpg");
+        testNavigateNextKeyEvent(testinfo, true, false, "wexor-tmg-L-2p8fapOA8-unsplash.jpg");
+        testNavigatePreviousKeyEvent(testinfo, true, false, "rachel-hisko-rEM3cK8F1pk-unsplash.jpg");
         testSelectFreehandDrawingModeKeyEvent();
         testSelectRectangleModeKeyEvent();
         testFocusCategorySearchFieldKeyEvent();
@@ -307,34 +313,38 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
         verifyThat(controller.getView().getEditor().getEditorToolBar().getFreehandModeButton().isSelected(), Matchers.is(true));
     }
 
-    private void testNavigatePreviousKeyEvent(TestInfo testinfo) {
+    private void testNavigatePreviousKeyEvent(TestInfo testinfo, boolean keyReleased, boolean ctrlReleased, String expectedTargetImageName) {
         KeyEvent navigatePreviousPressedEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.A, false, true, false, false);
 
         Platform.runLater(() -> controller.onRegisterSceneKeyPressed(navigatePreviousPressedEvent));
         WaitForAsyncUtils.waitForFxEvents();
 
-        KeyEvent navigatePreviousReleasedEvent = new KeyEvent(KeyEvent.KEY_RELEASED, "", "", KeyCode.A, false, true, false, false);
+        KeyEvent navigatePreviousReleasedEvent = new KeyEvent(KeyEvent.KEY_RELEASED, "", "",
+                keyReleased ? KeyCode.A : KeyCode.CONTROL, false, ctrlReleased, false, false);
         Platform.runLater(() -> controller.onRegisterSceneKeyReleased(navigatePreviousReleasedEvent));
         WaitForAsyncUtils.waitForFxEvents();
 
         waitUntilCurrentImageIsLoaded(testinfo);
 
-        verifyThat(model.getCurrentImageFile().getName(), Matchers.equalTo("rachel-hisko-rEM3cK8F1pk-unsplash.jpg"));
+        verifyThat(model.getCurrentImageFile().getName(), Matchers.equalTo(
+                expectedTargetImageName));
     }
 
-    private void testNavigateNextKeyEvent(TestInfo testinfo) {
+    private void testNavigateNextKeyEvent(TestInfo testinfo, boolean keyReleased, boolean ctrlReleased, String expectedTargetImageName) {
         KeyEvent navigateNextPressedEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.D, false, true, false, false);
 
         Platform.runLater(() -> controller.onRegisterSceneKeyPressed(navigateNextPressedEvent));
         WaitForAsyncUtils.waitForFxEvents();
 
-        KeyEvent navigateNextReleasedEvent = new KeyEvent(KeyEvent.KEY_RELEASED, "", "", KeyCode.D, false, true, false, false);
+        KeyEvent navigateNextReleasedEvent = new KeyEvent(KeyEvent.KEY_RELEASED, "", "",
+                keyReleased ? KeyCode.D : KeyCode.CONTROL, false, ctrlReleased, false, false);
         Platform.runLater(() -> controller.onRegisterSceneKeyReleased(navigateNextReleasedEvent));
         WaitForAsyncUtils.waitForFxEvents();
 
         waitUntilCurrentImageIsLoaded(testinfo);
 
-        verifyThat(model.getCurrentImageFile().getName(), Matchers.equalTo("wexor-tmg-L-2p8fapOA8-unsplash.jpg"));
+        verifyThat(model.getCurrentImageFile().getName(), Matchers.equalTo(
+                expectedTargetImageName));
     }
 
 }

--- a/src/test/java/com/github/mfl28/boundingboxeditor/controller/utils/KeyCombinationEventHandlerTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/controller/utils/KeyCombinationEventHandlerTests.java
@@ -21,6 +21,7 @@ package com.github.mfl28.boundingboxeditor.controller.utils;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyEvent;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,8 @@ class KeyCombinationEventHandlerTests {
     @Test
     void checkKeyCombinationEventHandlerWithNonNullHandlers() {
         KeyCodeCombination testCombination = new KeyCodeCombination(KeyCode.A, KeyCombination.SHIFT_DOWN);
+        KeyEvent trueEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.A, true, false, false, false);
+        KeyEvent falseEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.B, true, false, false, false);
 
         AtomicInteger numPressedHandled = new AtomicInteger();
         AtomicInteger numReleasedHandled = new AtomicInteger();
@@ -45,6 +48,10 @@ class KeyCombinationEventHandlerTests {
         Assertions.assertTrue(keyCombinationEventHandler.hasOnPressedHandler());
         Assertions.assertTrue(keyCombinationEventHandler.hasOnReleasedHandler());
         Assertions.assertEquals(keyCombinationEventHandler.getKeyCombination(), testCombination);
+        Assertions.assertTrue(keyCombinationEventHandler.handlesPressed(trueEvent));
+        Assertions.assertTrue(keyCombinationEventHandler.handlesReleased(trueEvent));
+        Assertions.assertFalse(keyCombinationEventHandler.handlesPressed(falseEvent));
+    Assertions.assertFalse(keyCombinationEventHandler.handlesReleased(falseEvent));
 
         keyCombinationEventHandler.onPressed(null);
         Assertions.assertEquals(1, numPressedHandled.get());
@@ -59,6 +66,8 @@ class KeyCombinationEventHandlerTests {
     @Test
     void checkKeyCombinationEventHandlerWithNullHandlers() {
         KeyCodeCombination testCombination = new KeyCodeCombination(KeyCode.A, KeyCombination.SHIFT_DOWN);
+        KeyEvent trueEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.A, true, false, false, false);
+        KeyEvent falseEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.B, true, false, false, false);
 
         KeyCombinationEventHandler keyCombinationEventHandler = new KeyCombinationEventHandler(
                 testCombination, null, null
@@ -67,9 +76,36 @@ class KeyCombinationEventHandlerTests {
         Assertions.assertFalse(keyCombinationEventHandler.hasOnPressedHandler());
         Assertions.assertFalse(keyCombinationEventHandler.hasOnReleasedHandler());
         Assertions.assertEquals(keyCombinationEventHandler.getKeyCombination(), testCombination);
+        Assertions.assertFalse(keyCombinationEventHandler.handlesPressed(trueEvent));
+        Assertions.assertFalse(keyCombinationEventHandler.handlesReleased(trueEvent));
+        Assertions.assertFalse(keyCombinationEventHandler.handlesPressed(falseEvent));
+        Assertions.assertFalse(keyCombinationEventHandler.handlesReleased(falseEvent));
+
 
         keyCombinationEventHandler.onPressed(null);
         keyCombinationEventHandler.onReleased(null);
+    }
+
+    @Test
+    void checkKeyCombinationEventHandlerWithNonNullReleaseMatcher() {
+        KeyCodeCombination testCombination = new KeyCodeCombination(KeyCode.A, KeyCombination.SHIFT_DOWN);
+        KeyEvent trueEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.A, true, false, false, false);
+        KeyEvent falseEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.B, true, false, false, false);
+
+        AtomicInteger numPressedHandled = new AtomicInteger();
+        AtomicInteger numReleasedHandled = new AtomicInteger();
+
+        KeyCombinationEventHandler keyCombinationEventHandler = new KeyCombinationEventHandler(
+                testCombination,
+                event -> numPressedHandled.addAndGet(1),
+                event -> numReleasedHandled.addAndGet(1),
+                event -> event.getCode() == KeyCode.B
+        );
+
+        Assertions.assertTrue(keyCombinationEventHandler.handlesPressed(trueEvent));
+        Assertions.assertFalse(keyCombinationEventHandler.handlesReleased(trueEvent));
+        Assertions.assertFalse(keyCombinationEventHandler.handlesPressed(falseEvent));
+        Assertions.assertTrue(keyCombinationEventHandler.handlesReleased(falseEvent));
     }
 
     @Test


### PR DESCRIPTION
* Fixes handling of partial navigation  key-combination release. Images now load correctly even if only a part of the navigation key-combination is released.
* Updates and extends unit tests.

Fixes #77 .