### PR TITLE
Make drawing mode selection toggles more compact

### DIFF
--- a/src/main/java/com/github/mfl28/boundingboxeditor/controller/Controller.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/controller/Controller.java
@@ -1618,11 +1618,11 @@ public class Controller {
                 new KeyCodeCombination(KeyCode.F, KeyCombination.SHORTCUT_DOWN, KeyCombination.ALT_DOWN);
         public static final KeyCombination deleteSelectedBoundingShape = new KeyCodeCombination(KeyCode.DELETE);
         public static final KeyCombination selectRectangleDrawingMode =
-                new KeyCodeCombination(KeyCode.K, KeyCombination.SHORTCUT_DOWN);
+                new KeyCodeCombination(KeyCode.DIGIT1, KeyCombination.SHORTCUT_DOWN);
         public static final KeyCombination selectPolygonDrawingMode =
-                new KeyCodeCombination(KeyCode.P, KeyCombination.SHORTCUT_DOWN);
+                new KeyCodeCombination(KeyCode.DIGIT2, KeyCombination.SHORTCUT_DOWN);
         public static final KeyCombination selectFreehandDrawingMode =
-                new KeyCodeCombination(KeyCode.S, KeyCombination.SHORTCUT_DOWN);
+                new KeyCodeCombination(KeyCode.DIGIT3, KeyCombination.SHORTCUT_DOWN);
         public static final KeyCombination removeEditingVerticesWhenBoundingPolygonSelected =
                 new KeyCodeCombination(KeyCode.DELETE, KeyCombination.SHIFT_DOWN);
         public static final KeyCombination addVerticesToPolygon =

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/EditorToolBarView.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/EditorToolBarView.java
@@ -72,9 +72,6 @@ public class EditorToolBarView extends ToolBar implements View {
     private static final String SHOW_BOUNDING_BOXES_ICON_BUTTON_ID = "show-bounding-boxes-icon";
     private static final String HIDE_BOUNDING_BOXES_ICON_BUTTON_ID = "hide-bounding-boxes-icon";
     private static final String RESET_IMAGE_SIZE_ICON_BUTTON_ID = "reset-image-size-icon";
-    private static final String RECTANGLE_MODE_BUTTON_TEXT = "Rectangle";
-    private static final String POLYGON_MODE_BUTTON_TEXT = "Polygon";
-    private static final String FREEHAND_MODE_BUTTON_TEXT = "Freehand";
     private static final String RECTANGLE_MODE_BUTTON_ICON_ID = "rectangle-mode-button-icon";
     private static final String FREEHAND_MODE_BUTTON_ICON_ID = "freehand-mode-button-icon";
     private static final String POLYGON_MODE_BUTTON_ICON_ID = "polygon-mode-button-icon";
@@ -82,17 +79,18 @@ public class EditorToolBarView extends ToolBar implements View {
     private static final String PREDICT_BUTTON_ID = "predict-button";
     private static final String FREEHAND_DRAWING_MODE = "Select Freehand Drawing-Mode";
     private static final String FREEHAND_DRAWING_MODE_TOOLTIP_TEXT = FREEHAND_DRAWING_MODE;
+    private static final String DRAWING_MODE_TOOLBOX_ID = "drawing-mode-toolbox";
 
     private final IconButton showBoundingShapesButton =
             new IconButton(SHOW_BOUNDING_BOXES_ICON_BUTTON_ID, IconButton.IconType.BACKGROUND);
     private final IconButton hideBoundingShapesButton =
             new IconButton(HIDE_BOUNDING_BOXES_ICON_BUTTON_ID, IconButton.IconType.BACKGROUND);
     private final ToggleButton rectangleModeButton =
-            createDrawModeButton(RECTANGLE_MODE_BUTTON_TEXT, RECTANGLE_MODE_BUTTON_ICON_ID);
+            createDrawModeButton("", RECTANGLE_MODE_BUTTON_ICON_ID);
     private final ToggleButton polygonModeButton =
-            createDrawModeButton(POLYGON_MODE_BUTTON_TEXT, POLYGON_MODE_BUTTON_ICON_ID);
+            createDrawModeButton("", POLYGON_MODE_BUTTON_ICON_ID);
     private final ToggleButton freehandModeButton =
-            createDrawModeButton(FREEHAND_MODE_BUTTON_TEXT, FREEHAND_MODE_BUTTON_ICON_ID);
+            createDrawModeButton("", FREEHAND_MODE_BUTTON_ICON_ID);
     private final ToggleGroup modeToggleGroup = new ToggleGroup();
 
     private final IconButton resetSizeAndCenterImageButton =
@@ -300,7 +298,7 @@ public class EditorToolBarView extends ToolBar implements View {
                 button.textFillProperty()));
 
         button.setGraphic(icon);
-        button.setContentDisplay(ContentDisplay.RIGHT);
+        button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
 
         button.setFocusTraversable(false);
         button.setPickOnBounds(true);
@@ -351,6 +349,8 @@ public class EditorToolBarView extends ToolBar implements View {
         modeToggleGroup.selectToggle(rectangleModeButton);
 
         predictButton.setId(PREDICT_BUTTON_ID);
+
+        drawingModeToolBox.setId(DRAWING_MODE_TOOLBOX_ID);
     }
 
     private void setUpInternalListeners() {

--- a/src/main/resources/stylesheets/scss/styles.scss
+++ b/src/main/resources/stylesheets/scss/styles.scss
@@ -697,6 +697,12 @@ $base-separator-line-color: derive($base-background-color, -15%);
     -fx-background-color: $base-background-light-color;
 }
 
+#drawing-mode-toolbox {
+    -fx-border-radius: 3px;
+    -fx-background-radius: 3px;
+    -fx-border-color: $base-alt-accent-color;
+}
+
 #bounding-box-explorer-top-panel {
     -fx-spacing: 10px;
 }

--- a/src/test/java/com/github/mfl28/boundingboxeditor/controller/SceneKeyShortcutTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/controller/SceneKeyShortcutTests.java
@@ -257,7 +257,7 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
     }
 
     private void testSelectPolygonModeKeyEvent() {
-        KeyEvent selectPolygonModeEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.P, false, true,false, false);
+        KeyEvent selectPolygonModeEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.DIGIT2, false, true,false, false);
         Platform.runLater(() -> controller.onRegisterSceneKeyPressed(selectPolygonModeEvent));
         WaitForAsyncUtils.waitForFxEvents();
 
@@ -298,7 +298,7 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
     }
 
     private void testSelectRectangleModeKeyEvent() {
-        KeyEvent selectRectangleModeEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.K, false, true,false, false);
+        KeyEvent selectRectangleModeEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.DIGIT1, false, true,false, false);
         Platform.runLater(() -> controller.onRegisterSceneKeyPressed(selectRectangleModeEvent));
         WaitForAsyncUtils.waitForFxEvents();
 
@@ -306,7 +306,7 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
     }
 
     private void testSelectFreehandDrawingModeKeyEvent() {
-        KeyEvent selectFreehandDrawingModeEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.S, false, true,false, false);
+        KeyEvent selectFreehandDrawingModeEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.DIGIT3, false, true,false, false);
         Platform.runLater(() -> controller.onRegisterSceneKeyPressed(selectFreehandDrawingModeEvent));
         WaitForAsyncUtils.waitForFxEvents();
 

--- a/src/test/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawingTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawingTests.java
@@ -78,7 +78,7 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
                    saveScreenshot(testinfo));
 
         // Select polygon drawing mode:
-        timeOutClickOn(robot, "Polygon", testinfo);
+        timeOutClickOn(robot, "#polygon-mode-button-icon", testinfo);
         WaitForAsyncUtils.waitForFxEvents();
 
         // Draw a bounding polygon.
@@ -291,7 +291,7 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
         WaitForAsyncUtils.waitForFxEvents();
 
         // Change drawing mode while construction is in progress.
-        timeOutClickOn(robot, "Rectangle", testinfo);
+        timeOutClickOn(robot, "#rectangle-mode-button-icon", testinfo);
         WaitForAsyncUtils.waitForFxEvents();
 
         verifyThat(mainView.getCurrentBoundingShapes(), Matchers.hasSize(1), saveScreenshot(testinfo));
@@ -378,7 +378,7 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
         WaitForAsyncUtils.waitForFxEvents();
 
         // Select polygon drawing mode:
-        timeOutClickOn(robot, "Freehand", testinfo);
+        timeOutClickOn(robot, "#freehand-mode-button-icon", testinfo);
         WaitForAsyncUtils.waitForFxEvents();
 
         // Draw a bounding polygon.


### PR DESCRIPTION
* Makes drawing-mode selection toggle box more compact - removes text descriptions. Improves visual appearance.
* Sets more logical keyboard shortcuts for drawing-mode selection: `Ctrl+1/2/3`. 
* Updates unit tests.

Closes #79 .