### PR TITLE
Refactor bounding shape drawing

### DIFF
--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingBoxDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingBoxDrawer.java
@@ -1,0 +1,84 @@
+package com.github.mfl28.boundingboxeditor.ui;
+
+import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;
+import com.github.mfl28.boundingboxeditor.utils.MathUtils;
+import javafx.geometry.Point2D;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+
+import java.util.List;
+
+
+public class BoundingBoxDrawer implements BoundingShapeDrawer {
+    private final ImageView imageView;
+    private final ToggleGroup toggleGroup;
+    private final List<BoundingShapeViewable> boundingShapes;
+
+    private BoundingBoxView boundingBoxView;
+
+    private boolean drawingInProgress = false;
+
+    public BoundingBoxDrawer(ImageView imageView, ToggleGroup toggleGroup, List<BoundingShapeViewable> boundingShapes) {
+        this.imageView = imageView;
+        this.toggleGroup = toggleGroup;
+        this.boundingShapes = boundingShapes;
+    }
+
+    @Override
+    public void initializeShape(MouseEvent event, ObjectCategory objectCategory) {
+        if (event.getEventType().equals(MouseEvent.MOUSE_PRESSED) && event.getButton().equals(MouseButton.PRIMARY)) {
+            Point2D parentCoordinates = imageView.localToParent(event.getX(), event.getY());
+
+            boundingBoxView = new BoundingBoxView(objectCategory);
+            boundingBoxView.getConstructionAnchorLocal().setFromMouseEvent(event);
+            boundingBoxView.setToggleGroup(toggleGroup);
+
+            boundingBoxView.setX(parentCoordinates.getX());
+            boundingBoxView.setY(parentCoordinates.getY());
+            boundingBoxView.setWidth(0);
+            boundingBoxView.setHeight(0);
+
+            boundingShapes.add(boundingBoxView);
+
+            boundingBoxView.autoScaleWithBounds(imageView.boundsInParentProperty());
+            toggleGroup.selectToggle(boundingBoxView);
+
+            drawingInProgress = true;
+        }
+    }
+
+    @Override
+    public void updateShape(MouseEvent event) {
+        if (event.getEventType().equals(MouseEvent.MOUSE_DRAGGED) && event.getButton().equals(MouseButton.PRIMARY)) {
+            final Point2D clampedEventXY =
+                    MathUtils.clampWithinBounds(event.getX(), event.getY(), imageView.getBoundsInLocal());
+
+            DragAnchor constructionAnchor = boundingBoxView.getConstructionAnchorLocal();
+            Point2D parentCoordinates =
+                    imageView.localToParent(Math.min(clampedEventXY.getX(), constructionAnchor.getX()),
+                            Math.min(clampedEventXY.getY(), constructionAnchor.getY()));
+
+            boundingBoxView.setX(parentCoordinates.getX());
+            boundingBoxView.setY(parentCoordinates.getY());
+            boundingBoxView.setWidth(Math.abs(clampedEventXY.getX() - constructionAnchor.getX()));
+            boundingBoxView.setHeight(Math.abs(clampedEventXY.getY() - constructionAnchor.getY()));
+        }
+    }
+
+    @Override
+    public void finalizeShape() {
+        drawingInProgress = false;
+    }
+
+    @Override
+    public boolean isDrawingInProgress() {
+        return drawingInProgress;
+    }
+
+    @Override
+    public EditorImagePaneView.DrawingMode getDrawingMode() {
+        return EditorImagePaneView.DrawingMode.BOX;
+    }
+}

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingBoxDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingBoxDrawer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Markus Fleischhacker <markus.fleischhacker28@gmail.com>
+ *
+ * This file is part of Bounding Box Editor
+ *
+ * Bounding Box Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bounding Box Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Bounding Box Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.github.mfl28.boundingboxeditor.ui;
 
 import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingFreeHandShapeDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingFreeHandShapeDrawer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Markus Fleischhacker <markus.fleischhacker28@gmail.com>
+ *
+ * This file is part of Bounding Box Editor
+ *
+ * Bounding Box Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bounding Box Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Bounding Box Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.github.mfl28.boundingboxeditor.ui;
 
 import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingFreeHandShapeDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingFreeHandShapeDrawer.java
@@ -1,0 +1,120 @@
+package com.github.mfl28.boundingboxeditor.ui;
+
+import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;
+import com.github.mfl28.boundingboxeditor.utils.MathUtils;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.geometry.Point2D;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.shape.ClosePath;
+
+import java.util.List;
+
+public class BoundingFreeHandShapeDrawer implements BoundingShapeDrawer {
+
+    private final ImageView imageView;
+    private final ToggleGroup toggleGroup;
+    private final List<BoundingShapeViewable> boundingShapes;
+    private final BooleanProperty autoSimplify;
+    private final DoubleProperty simplifyRelativeDistanceTolerance;
+    private boolean drawingInProgress = false;
+    private BoundingFreehandShapeView boundingFreehandShapeView;
+
+    public BoundingFreeHandShapeDrawer(ImageView imageView, ToggleGroup toggleGroup, List<BoundingShapeViewable> boundingShapes,
+                                       BooleanProperty autoSimplify, DoubleProperty simplifyRelativeDistanceTolerance) {
+        this.imageView = imageView;
+        this.toggleGroup = toggleGroup;
+        this.boundingShapes = boundingShapes;
+        this.autoSimplify = autoSimplify;
+        this.simplifyRelativeDistanceTolerance = simplifyRelativeDistanceTolerance;
+    }
+
+    @Override
+    public void initializeShape(MouseEvent event, ObjectCategory objectCategory) {
+        if (event.getEventType().equals(MouseEvent.MOUSE_PRESSED) && event.getButton().equals(MouseButton.PRIMARY)) {
+            Point2D parentCoordinates = imageView.localToParent(event.getX(), event.getY());
+
+            boundingFreehandShapeView = new BoundingFreehandShapeView(objectCategory);
+            boundingFreehandShapeView.setToggleGroup(toggleGroup);
+
+            boundingShapes.add(boundingFreehandShapeView);
+
+            boundingFreehandShapeView.autoScaleWithBounds(imageView.boundsInParentProperty());
+
+            boundingFreehandShapeView.setVisible(true);
+            toggleGroup.selectToggle(boundingFreehandShapeView);
+            boundingFreehandShapeView.addMoveTo(parentCoordinates.getX(), parentCoordinates.getY());
+            drawingInProgress = true;
+        }
+    }
+
+    @Override
+    public void updateShape(MouseEvent event) {
+        if (event.getEventType().equals(MouseEvent.MOUSE_DRAGGED) && event.getButton().equals(MouseButton.PRIMARY)) {
+            final Point2D clampedEventXY =
+                    MathUtils.clampWithinBounds(event.getX(), event.getY(), imageView.getBoundsInLocal());
+
+            Point2D parentCoordinates =
+                    imageView.localToParent(clampedEventXY.getX(), clampedEventXY.getY());
+
+            boundingFreehandShapeView.addLineTo(parentCoordinates.getX(), parentCoordinates.getY());
+        }
+    }
+
+    @Override
+    public void finalizeShape() {
+        boundingFreehandShapeView.getElements().add(new ClosePath());
+
+        BoundingPolygonView boundingPolygonView = new BoundingPolygonView(
+                boundingFreehandShapeView.getViewData().getObjectCategory());
+
+        final List<Double> pointsInImage = boundingFreehandShapeView.getPointsInImage();
+
+        boundingPolygonView.setEditing(true);
+
+        for(int i = 0; i < pointsInImage.size(); i += 2) {
+            boundingPolygonView.appendNode(pointsInImage.get(i), pointsInImage.get(i + 1));
+        }
+
+        if(autoSimplify.get()) {
+            boundingPolygonView.simplify(simplifyRelativeDistanceTolerance.get(),
+                    boundingFreehandShapeView.getViewData().autoScaleBounds().getValue());
+        }
+
+        boundingPolygonView.setToggleGroup(toggleGroup);
+
+        boundingShapes.remove(boundingFreehandShapeView);
+
+        ObjectCategoryTreeItem parentTreeItem = (ObjectCategoryTreeItem) boundingFreehandShapeView.getViewData()
+                .getTreeItem().getParent();
+        parentTreeItem.detachBoundingShapeTreeItemChild(boundingFreehandShapeView.getViewData().getTreeItem());
+
+        if(parentTreeItem.getChildren().isEmpty()) {
+            parentTreeItem.getParent().getChildren().remove(parentTreeItem);
+        }
+
+        boundingShapes.add(boundingPolygonView);
+
+        boundingPolygonView.autoScaleWithBounds(imageView.boundsInParentProperty());
+        boundingPolygonView.setVisible(true);
+        toggleGroup.selectToggle(boundingPolygonView);
+
+        boundingPolygonView.setConstructing(false);
+        boundingPolygonView.setEditing(false);
+
+        drawingInProgress = false;
+    }
+
+    @Override
+    public boolean isDrawingInProgress() {
+        return drawingInProgress;
+    }
+
+    @Override
+    public EditorImagePaneView.DrawingMode getDrawingMode() {
+        return EditorImagePaneView.DrawingMode.FREEHAND;
+    }
+}

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Markus Fleischhacker <markus.fleischhacker28@gmail.com>
+ *
+ * This file is part of Bounding Box Editor
+ *
+ * Bounding Box Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bounding Box Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Bounding Box Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.github.mfl28.boundingboxeditor.ui;
 
 import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawer.java
@@ -1,0 +1,75 @@
+package com.github.mfl28.boundingboxeditor.ui;
+
+import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;
+import javafx.geometry.Point2D;
+import javafx.scene.Node;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+
+import java.util.List;
+
+public class BoundingPolygonDrawer implements BoundingShapeDrawer {
+    private final ImageView imageView;
+    private final ToggleGroup toggleGroup;
+    private final List<BoundingShapeViewable> boundingShapes;
+    private boolean drawingInProgress = false;
+    private BoundingPolygonView boundingPolygonView;
+
+    public BoundingPolygonDrawer(ImageView imageView, ToggleGroup toggleGroup, List<BoundingShapeViewable> boundingShapes) {
+
+        this.imageView = imageView;
+        this.toggleGroup = toggleGroup;
+        this.boundingShapes = boundingShapes;
+    }
+
+    @Override
+    public void initializeShape(MouseEvent event, ObjectCategory objectCategory) {
+        if(event.getEventType().equals(MouseEvent.MOUSE_PRESSED) && event.getButton().equals(MouseButton.PRIMARY)) {
+            boundingShapes.forEach(boundingShapeViewable -> ((Node) boundingShapeViewable).setMouseTransparent(true));
+            boundingPolygonView = new BoundingPolygonView(objectCategory);
+            boundingPolygonView.setToggleGroup(toggleGroup);
+            boundingPolygonView.setConstructing(true);
+
+            boundingShapes.add(boundingPolygonView);
+
+            boundingPolygonView.autoScaleWithBounds(imageView.boundsInParentProperty());
+            boundingPolygonView.setMouseTransparent(true);
+            boundingPolygonView.setVisible(true);
+            toggleGroup.selectToggle(boundingPolygonView);
+
+            updateShape(event);
+        }
+    }
+
+    @Override
+    public void updateShape(MouseEvent event) {
+        if(event.getEventType().equals(MouseEvent.MOUSE_PRESSED) && event.getButton().equals(MouseButton.PRIMARY)) {
+            Point2D parentCoordinates = imageView.localToParent(event.getX(), event.getY());
+            boundingPolygonView.appendNode(parentCoordinates.getX(), parentCoordinates.getY());
+            boundingPolygonView.setEditing(true);
+
+            drawingInProgress = true;
+        }
+    }
+
+    @Override
+    public void finalizeShape() {
+        boundingPolygonView.setConstructing(false);
+        boundingPolygonView.setEditing(false);
+
+        boundingShapes.forEach(boundingShapeViewable -> ((Node) boundingShapeViewable).setMouseTransparent(false));
+        drawingInProgress = false;
+    }
+
+    @Override
+    public boolean isDrawingInProgress() {
+        return drawingInProgress;
+    }
+
+    @Override
+    public EditorImagePaneView.DrawingMode getDrawingMode() {
+        return EditorImagePaneView.DrawingMode.POLYGON;
+    }
+}

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingShapeDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingShapeDrawer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2023 Markus Fleischhacker <markus.fleischhacker28@gmail.com>
+ *
+ * This file is part of Bounding Box Editor
+ *
+ * Bounding Box Editor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bounding Box Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Bounding Box Editor. If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.github.mfl28.boundingboxeditor.ui;
 
 import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingShapeDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingShapeDrawer.java
@@ -1,0 +1,13 @@
+package com.github.mfl28.boundingboxeditor.ui;
+
+import com.github.mfl28.boundingboxeditor.model.data.ObjectCategory;
+import javafx.scene.input.MouseEvent;
+
+public interface BoundingShapeDrawer {
+    void initializeShape(MouseEvent event, ObjectCategory objectCategory);
+    void updateShape(MouseEvent event);
+    void finalizeShape();
+    boolean isDrawingInProgress();
+
+    EditorImagePaneView.DrawingMode getDrawingMode();
+}

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/EditorView.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/EditorView.java
@@ -86,24 +86,18 @@ public class EditorView extends BorderPane implements View {
                          .setOnAction(event -> editorImagePaneView.resetImageViewSize());
 
         editorToolBarView.getRectangleModeButton().selectedProperty().addListener((observable, oldValue, newValue) -> {
-            editorImagePaneView.setBoundingPolygonsEditingAndConstructing(false);
-
             if(Boolean.TRUE.equals(newValue)) {
                 editorImagePaneView.setDrawingMode(EditorImagePaneView.DrawingMode.BOX);
             }
         });
 
         editorToolBarView.getPolygonModeButton().selectedProperty().addListener((observable, oldValue, newValue) -> {
-            editorImagePaneView.setBoundingPolygonsEditingAndConstructing(false);
-
             if(Boolean.TRUE.equals(newValue)) {
                 editorImagePaneView.setDrawingMode(EditorImagePaneView.DrawingMode.POLYGON);
             }
         });
 
         editorToolBarView.getFreehandModeButton().selectedProperty().addListener((observable, oldValue, newValue) -> {
-            editorImagePaneView.setBoundingPolygonsEditingAndConstructing(false);
-
             if(Boolean.TRUE.equals(newValue)) {
                 editorImagePaneView.setDrawingMode(EditorImagePaneView.DrawingMode.FREEHAND);
             }

--- a/src/test/java/com/github/mfl28/boundingboxeditor/controller/SceneKeyShortcutTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/controller/SceneKeyShortcutTests.java
@@ -21,6 +21,7 @@ package com.github.mfl28.boundingboxeditor.controller;
 import com.github.mfl28.boundingboxeditor.BoundingBoxEditorTestBase;
 import com.github.mfl28.boundingboxeditor.controller.utils.KeyCombinationEventHandler;
 import com.github.mfl28.boundingboxeditor.ui.BoundingPolygonView;
+import com.github.mfl28.boundingboxeditor.ui.EditorImagePaneView;
 import javafx.application.Platform;
 import javafx.event.EventType;
 import javafx.geometry.Point2D;
@@ -113,6 +114,18 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
                                 TIMEOUT_DURATION_IN_SEC +
                                 " sec."));
 
+        verifyThat(mainView.getEditorImagePane().isDrawingInProgress(), Matchers.equalTo(true));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
+                Matchers.equalTo(EditorImagePaneView.DrawingMode.POLYGON));
+
+        // Clicking outside the imageview should finalize any drawn shapes.
+        robot.clickOn(mainView.getStatusBar());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        verifyThat(mainView.getEditorImagePane().isDrawingInProgress(), Matchers.equalTo(false));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
+                Matchers.equalTo(EditorImagePaneView.DrawingMode.NONE));
+
         BoundingPolygonView polygon = (BoundingPolygonView) mainView.getCurrentBoundingShapes().get(0);
         verifyThat(polygon.isSelected(), Matchers.is(true));
         verifyThat(polygon, NodeMatchers.isVisible());
@@ -135,6 +148,9 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
                 new Point2D(targetImageViewPointRatios2[4], targetImageViewPointRatios2[5]),
                 new Point2D(targetImageViewPointRatios2[6], targetImageViewPointRatios2[7]));
 
+        WaitForAsyncUtils.waitForFxEvents();
+
+        robot.clickOn(mainView.getStatusBar());
         WaitForAsyncUtils.waitForFxEvents();
 
         Assertions.assertDoesNotThrow(() -> WaitForAsyncUtils.waitFor(TIMEOUT_DURATION_IN_SEC, TimeUnit.SECONDS,
@@ -324,7 +340,6 @@ class SceneKeyShortcutTests extends BoundingBoxEditorTestBase {
         Platform.runLater(() -> controller.onRegisterSceneKeyReleased(focusTagTextFieldEvent));
         WaitForAsyncUtils.waitForFxEvents();
 
-        // No bounding-shapes are selected, therefore tag text-field should be disabled.
         verifyThat(controller.getView().getTagInputField().isFocused(), Matchers.is(true));
 
         robot.push(KeyCode.ESCAPE);

--- a/src/test/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawingTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawingTests.java
@@ -419,7 +419,7 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
         verifyThat(boundingFreehandShapeView.isSelected(), Matchers.equalTo(true), saveScreenshot(testinfo));
         verifyThat(mainView.getEditorImagePane().getBoundingShapeSelectionGroup().getSelectedToggle(),
                 Matchers.equalTo(boundingFreehandShapeView), saveScreenshot(testinfo));
-        verifyThat(mainView.getEditorImagePane().isFreehandDrawingInProgress(), Matchers.equalTo(true));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(), Matchers.equalTo(EditorImagePaneView.DrawingMode.FREEHAND));
 
         int numPathElements = boundingFreehandShapeView.getElements().size();
 
@@ -453,7 +453,8 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
                         .getSelectedItem().isHasAssignedBoundingShapes(), Matchers.is(true),
                 saveScreenshot(testinfo));
 
-        verifyThat(mainView.getEditorImagePane().isFreehandDrawingInProgress(), Matchers.equalTo(false));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
+                Matchers.not(Matchers.equalTo(EditorImagePaneView.DrawingMode.FREEHAND)));
 
         verifyThat(mainView.getCurrentBoundingShapes().get(0), Matchers.instanceOf(BoundingPolygonView.class),
                 saveScreenshot(testinfo));


### PR DESCRIPTION
* Refactors bounding shape drawing using new `BoundingShapeDrawer` interface.
* Adds listeners that trigger bounding shape drawing finalization whenever the user clicks outside of the imageview or requests the program to exit.
* While drawing a polygon (after initial node click), all other existing bounding shapes in the scene are set to be mouse-transparent. This allows to draw polygons over other shapes. The mouse-transparency is reset when the drawn polygon is finalized.
* As with the other shapes, when drawing a polygon (by clicking to add nodes) keyboard-shortcuts are now ignored until the polygon is finalized.
* Updates and extends unit tests.

Closes #102 .