### PR TITLE
Fix shape group mouse-transparency when drawing

### DIFF
--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawer.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawer.java
@@ -45,7 +45,6 @@ public class BoundingPolygonDrawer implements BoundingShapeDrawer {
     @Override
     public void initializeShape(MouseEvent event, ObjectCategory objectCategory) {
         if(event.getEventType().equals(MouseEvent.MOUSE_PRESSED) && event.getButton().equals(MouseButton.PRIMARY)) {
-            boundingShapes.forEach(boundingShapeViewable -> ((Node) boundingShapeViewable).setMouseTransparent(true));
             boundingPolygonView = new BoundingPolygonView(objectCategory);
             boundingPolygonView.setToggleGroup(toggleGroup);
             boundingPolygonView.setConstructing(true);
@@ -53,7 +52,6 @@ public class BoundingPolygonDrawer implements BoundingShapeDrawer {
             boundingShapes.add(boundingPolygonView);
 
             boundingPolygonView.autoScaleWithBounds(imageView.boundsInParentProperty());
-            boundingPolygonView.setMouseTransparent(true);
             boundingPolygonView.setVisible(true);
             toggleGroup.selectToggle(boundingPolygonView);
 
@@ -77,7 +75,6 @@ public class BoundingPolygonDrawer implements BoundingShapeDrawer {
         boundingPolygonView.setConstructing(false);
         boundingPolygonView.setEditing(false);
 
-        boundingShapes.forEach(boundingShapeViewable -> ((Node) boundingShapeViewable).setMouseTransparent(false));
         drawingInProgress = false;
     }
 

--- a/src/main/java/com/github/mfl28/boundingboxeditor/ui/EditorImagePaneView.java
+++ b/src/main/java/com/github/mfl28/boundingboxeditor/ui/EditorImagePaneView.java
@@ -58,6 +58,7 @@ public class EditorImagePaneView extends ScrollPane implements View {
     private static final int MAXIMUM_IMAGE_WIDTH = 3072;
     private static final int MAXIMUM_IMAGE_HEIGHT = 3072;
     private static final double ZOOM_SCALE_DELTA = 0.05;
+    private static final String BOUNDING_SHAPE_SCENE_GROUP_ID = "bounding-shape-scene-group";
 
     private final ImageView imageView = new ImageView();
     private final SimpleBooleanProperty maximizeImageView = new SimpleBooleanProperty(true);
@@ -93,6 +94,7 @@ public class EditorImagePaneView extends ScrollPane implements View {
         setHbarPolicy(ScrollBarPolicy.NEVER);
 
         boundingShapeSceneGroup.setManaged(false);
+        boundingShapeSceneGroup.setId(BOUNDING_SHAPE_SCENE_GROUP_ID);
 
         setUpImageView();
         setUpInternalListeners();
@@ -129,6 +131,7 @@ public class EditorImagePaneView extends ScrollPane implements View {
 
             if (boundingShapeDrawer != null) {
                 boundingShapeDrawer.initializeShape(event, selectedCategory.get());
+                boundingShapeSceneGroup.setMouseTransparent(true);
             }
         }
     }
@@ -142,6 +145,7 @@ public class EditorImagePaneView extends ScrollPane implements View {
     public void finalizeBoundingShapeDrawing() {
         if (boundingShapeDrawer != null && boundingShapeDrawer.isDrawingInProgress()) {
             boundingShapeDrawer.finalizeShape();
+            boundingShapeSceneGroup.setMouseTransparent(false);
         }
     }
 

--- a/src/test/java/com/github/mfl28/boundingboxeditor/BoundingBoxEditorTestBase.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/BoundingBoxEditorTestBase.java
@@ -147,6 +147,15 @@ public class BoundingBoxEditorTestBase {
                 .release(MouseButton.PRIMARY);
     }
 
+    protected void moveRelativeToImageViewNoRelease(FxRobot robot, Point2D startPointRatios, Point2D endPointRatios) {
+        Point2D startPoint = getScreenPointFromRatios(mainView.getEditorImageView(), startPointRatios);
+        Point2D endPoint = getScreenPointFromRatios(mainView.getEditorImageView(), endPointRatios);
+
+        robot.moveTo(startPoint)
+                .press(MouseButton.PRIMARY)
+                .moveTo(endPoint);
+    }
+
     protected void moveAndClickRelativeToImageView(FxRobot robot, MouseButton mousebutton, Point2D... points) {
         for(Point2D point : points) {
             robot.moveTo(getScreenPointFromRatios(mainView.getEditorImageView(), point)).clickOn(mousebutton);

--- a/src/test/java/com/github/mfl28/boundingboxeditor/ui/BoundingBoxDrawingTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/ui/BoundingBoxDrawingTests.java
@@ -85,7 +85,7 @@ class BoundingBoxDrawingTests extends BoundingBoxEditorTestBase {
                    saveScreenshot(testinfo));
 
         // Draw a bounding box.
-        moveRelativeToImageView(robot, new Point2D(0.25, 0.25), new Point2D(0.75, 0.75));
+        moveRelativeToImageViewNoRelease(robot, new Point2D(0.25, 0.25), new Point2D(0.75, 0.75));
         WaitForAsyncUtils.waitForFxEvents();
 
         int drawnBoundingBoxFileIndex = model.getCurrentFileIndex();
@@ -98,6 +98,18 @@ class BoundingBoxDrawingTests extends BoundingBoxEditorTestBase {
                                                                                    " found in " +
                                                                                    TIMEOUT_DURATION_IN_SEC +
                                                                                    " sec."));
+        verifyThat(mainView.getEditorImagePane().isDrawingInProgress(), Matchers.is(true));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
+                Matchers.equalTo(EditorImagePaneView.DrawingMode.BOX));
+        verifyThat(robot.lookup("#bounding-shape-scene-group").query().isMouseTransparent(), Matchers.is(true));
+
+        robot.release(MouseButton.PRIMARY);
+        WaitForAsyncUtils.waitForFxEvents();
+
+        verifyThat(mainView.getEditorImagePane().isDrawingInProgress(), Matchers.is(false));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
+                Matchers.equalTo(EditorImagePaneView.DrawingMode.NONE));
+        verifyThat(robot.lookup("#bounding-shape-scene-group").query().isMouseTransparent(), Matchers.is(false));
 
         verifyThat(model.getCategoryToAssignedBoundingShapesCountMap().get(testCategoryName), Matchers.equalTo(1),
                    saveScreenshot(testinfo));

--- a/src/test/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawingTests.java
+++ b/src/test/java/com/github/mfl28/boundingboxeditor/ui/BoundingPolygonDrawingTests.java
@@ -19,18 +19,13 @@
 package com.github.mfl28.boundingboxeditor.ui;
 
 import com.github.mfl28.boundingboxeditor.BoundingBoxEditorTestBase;
-import javafx.css.Match;
-import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
-import javafx.geometry.Rectangle2D;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.stage.Stage;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.AllOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -132,6 +127,10 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
 
         verifyThat(mainView.getEditorImagePane().getBoundingShapeSelectionGroup().getSelectedToggle(),
                    Matchers.equalTo(drawnBoundingPolygon), saveScreenshot(testinfo));
+        verifyThat(mainView.getEditorImagePane().isDrawingInProgress(), Matchers.is(true));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
+                Matchers.equalTo(EditorImagePaneView.DrawingMode.POLYGON));
+        verifyThat(robot.lookup("#bounding-shape-scene-group").query().isMouseTransparent(), Matchers.is(true));
 
         robot.rightClickOn(mainView.getEditorImageView());
         WaitForAsyncUtils.waitForFxEvents();
@@ -141,6 +140,11 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
         verifyThat(drawnBoundingPolygon.isEditing(), Matchers.equalTo(false), saveScreenshot(testinfo));
         verifyThat(mainView.getEditorImagePane().getBoundingShapeSelectionGroup().getSelectedToggle(),
                    Matchers.nullValue(), saveScreenshot(testinfo));
+        verifyThat(mainView.getEditorImagePane().isDrawingInProgress(), Matchers.is(false));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
+                Matchers.equalTo(EditorImagePaneView.DrawingMode.NONE));
+        verifyThat(robot.lookup("#bounding-shape-scene-group").query().isMouseTransparent(), Matchers.is(false));
+
 
         robot.clickOn(drawnBoundingPolygon, MouseButton.MIDDLE);
         WaitForAsyncUtils.waitForFxEvents();
@@ -422,6 +426,10 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
         verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(), Matchers.equalTo(EditorImagePaneView.DrawingMode.FREEHAND));
 
         int numPathElements = boundingFreehandShapeView.getElements().size();
+        verifyThat(mainView.getEditorImagePane().isDrawingInProgress(), Matchers.is(true));
+        verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
+                Matchers.equalTo(EditorImagePaneView.DrawingMode.FREEHAND));
+        verifyThat(robot.lookup("#bounding-shape-scene-group").query().isMouseTransparent(), Matchers.is(true));
 
 
         robot.moveTo(screenPoints.get(1));
@@ -454,7 +462,9 @@ class BoundingPolygonDrawingTests extends BoundingBoxEditorTestBase {
                 saveScreenshot(testinfo));
 
         verifyThat(mainView.getEditorImagePane().getCurrentBoundingShapeDrawingMode(),
-                Matchers.not(Matchers.equalTo(EditorImagePaneView.DrawingMode.FREEHAND)));
+                Matchers.equalTo(EditorImagePaneView.DrawingMode.NONE));
+        verifyThat(mainView.getEditorImagePane().isDrawingInProgress(), Matchers.is(false));
+        verifyThat(robot.lookup("#bounding-shape-scene-group").query().isMouseTransparent(), Matchers.is(false));
 
         verifyThat(mainView.getCurrentBoundingShapes().get(0), Matchers.instanceOf(BoundingPolygonView.class),
                 saveScreenshot(testinfo));


### PR DESCRIPTION
* Sets bounding shape group mouse-transparent whenever shape drawing is initialized and resets it on drawing-finalization. This presents bounding shapes from intercepting mouse events while drawing is in progress.
* Adds mouse-transparency checks to bounding shape drawing tests.

Fixes #111.